### PR TITLE
Fix #71 Hard dependency to MVC setup

### DIFF
--- a/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -10,9 +10,7 @@ namespace JsonApiDotNetCore.Routing
             app.UseMiddleware<RequestMiddleware>();
 
             if (useMvc)
-            {
                 app.UseMvc();
-            }
 
             return app;
         }

--- a/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -5,11 +5,14 @@ namespace JsonApiDotNetCore.Routing
 {
     public static class IApplicationBuilderExtensions
     {
-        public static IApplicationBuilder UseJsonApi(this IApplicationBuilder app)
+        public static IApplicationBuilder UseJsonApi(this IApplicationBuilder app, bool useMvc = true)
         {
             app.UseMiddleware<RequestMiddleware>();
 
-            app.UseMvc();
+            if (useMvc)
+            {
+                app.UseMvc();
+            }
 
             return app;
         }

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.2</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>JsonApiDotNetCore</AssemblyName>
     <PackageId>JsonApiDotNetCore</PackageId>


### PR DESCRIPTION
Offers decoupling of the dependency to MVC setup in IApplicationBuilderExtensions. Default behavior is still to use MVC.