### PR TITLE
fix(RelationshipAttribute): correct Equals and ToString

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Install-Package JsonApiDotnetCore
 
 - project.json
 ```json
-"JsonApiDotNetCore": "1.2.0"
+"JsonApiDotNetCore": "1.2.1"
 ```
 
 - *.csproj
 ```xml
 <ItemGroup>
     <!-- ... -->
-    <PackageReference Include="JsonApiDotNetCore" Version="1.2.0" />
+    <PackageReference Include="JsonApiDotNetCore" Version="1.2.1" />
 </ItemGroup>
 ```
 

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>JsonApiDotNetCore</AssemblyName>
     <PackageId>JsonApiDotNetCore</PackageId>

--- a/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
@@ -16,5 +16,20 @@ namespace JsonApiDotNetCore.Models
         public bool IsHasOne { get { return this.GetType() == typeof(HasOneAttribute); } }
 
         public abstract void SetValue(object entity, object newValue);
+
+        public override string ToString()
+        {
+            return base.ToString() + ":" + PublicRelationshipName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            RelationshipAttribute attr = obj as RelationshipAttribute;
+            if (attr == null)
+            {
+                return false;
+            }
+            return IsHasMany == attr.IsHasMany && PublicRelationshipName.Equals(attr.PublicRelationshipName);
+        }
     }
 }

--- a/test/JsonApiDotNetCoreExampleTests/Unit/Models/AttributesEqualsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Unit/Models/AttributesEqualsTests.cs
@@ -1,0 +1,75 @@
+﻿using JsonApiDotNetCore.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace JsonApiDotNetCoreExampleTests.Unit.Models
+{
+    public class AttributesEqualsTests
+    {
+        [Fact]
+        public void HasManyAttribute_Equals_Returns_True_When_Same_Name()
+        {
+            var a = new HasManyAttribute("test");
+            var b = new HasManyAttribute("test");
+
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void HasManyAttribute_Equals_Returns_False_When_Different_Name()
+        {
+            var a = new HasManyAttribute("test");
+            var b = new HasManyAttribute("test2");
+
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void HasOneAttribute_Equals_Returns_True_When_Same_Name()
+        {
+            var a = new HasOneAttribute("test");
+            var b = new HasOneAttribute("test");
+
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void HasOneAttribute_Equals_Returns_False_When_Different_Name()
+        {
+            var a = new HasOneAttribute("test");
+            var b = new HasOneAttribute("test2");
+
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void AttrAttribute_Equals_Returns_True_When_Same_Name()
+        {
+            var a = new AttrAttribute("test");
+            var b = new AttrAttribute("test");
+
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void AttrAttribute_Equals_Returns_False_When_Different_Name()
+        {
+            var a = new AttrAttribute("test");
+            var b = new AttrAttribute("test2");
+
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void HasManyAttribute_Doesnt_Equal_HasOneAttribute_With_Same_Name()
+        {
+            RelationshipAttribute a = new HasManyAttribute("test");
+            RelationshipAttribute b = new HasOneAttribute("test");
+
+            Assert.NotEqual(a, b);
+            Assert.NotEqual(b, a);
+        }
+    }
+}


### PR DESCRIPTION
`IJsonApiContext.RelationshipsToUpdate` is defined as `Dictionary<RelationshipAttribute, object>`, however `RelationshipAttribute.Equals` seems to compare only class name, and so, having several relationships of same type caused only first one to be saved with last one's id (which may work with autoincrement ids by chance, but immediately failed with Guids).

This PR adds correct Equals which checks name and type of relationship. Also adds `ToString` for easier debugging (I thought it is used for default `Equals` implementation).

I didn't want to create a full acceptance test for this case, just made unit tests.