### PR TITLE
Feat/allow non dasherized routes

### DIFF
--- a/src/JsonApiDotNetCore/Internal/DasherizedRoutingConvention.cs
+++ b/src/JsonApiDotNetCore/Internal/DasherizedRoutingConvention.cs
@@ -1,5 +1,6 @@
 // REF: https://github.com/aspnet/Entropy/blob/dev/samples/Mvc.CustomRoutingConvention/NameSpaceRoutingConvention.cs
 // REF: https://github.com/aspnet/Mvc/issues/5691
+using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Extensions;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
@@ -12,17 +13,28 @@ namespace JsonApiDotNetCore.Internal
         {
             _namespace = nspace;
         }
-        
+
         public void Apply(ApplicationModel application)
         {
             foreach (var controller in application.Controllers)
-            {
-                var template = $"{_namespace}/{controller.ControllerName.Dasherize()}";
-                controller.Selectors[0].AttributeRouteModel = new AttributeRouteModel()
+            {                
+                if (IsJsonApiController(controller))
                 {
-                    Template = template
-                };
+                    var template = $"{_namespace}/{controller.ControllerName.Dasherize()}";
+                    controller.Selectors[0].AttributeRouteModel = new AttributeRouteModel()
+                    {
+                        Template = template
+                    };
+                }
             }
+        }
+
+        private bool IsJsonApiController(ControllerModel controller) 
+        {
+            var controllerBaseType = controller.ControllerType.BaseType;
+            if(!controllerBaseType.IsConstructedGenericType) return false;
+            var genericTypeDefinition = controllerBaseType.GetGenericTypeDefinition();
+            return (genericTypeDefinition == typeof(JsonApiController<,>) || genericTypeDefinition == typeof(JsonApiController<>));
         }
     }
 }

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>JsonApiDotNetCore</AssemblyName>
     <PackageId>JsonApiDotNetCore</PackageId>

--- a/src/JsonApiDotNetCoreExample/Controllers/TestValuesController.cs
+++ b/src/JsonApiDotNetCoreExample/Controllers/TestValuesController.cs
@@ -2,14 +2,14 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace JsonApiDotNetCoreExample.Controllers
 {
-  [Route("[controller]")]
-  public class TestValuesController : Controller
-  {
-    [HttpGet]
-    public IActionResult Get()
+    [Route("[controller]")]
+    public class TestValuesController : Controller
     {
-      var result = new string[] { "value" };
-      return Ok(result);
+        [HttpGet]
+        public IActionResult Get()
+        {
+            var result = new string[] { "value" };
+            return Ok(result);
+        }
     }
-  }
 }

--- a/src/JsonApiDotNetCoreExample/Controllers/TestValuesController.cs
+++ b/src/JsonApiDotNetCoreExample/Controllers/TestValuesController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace JsonApiDotNetCoreExample.Controllers
+{
+  [Route("[controller]")]
+  public class TestValuesController : Controller
+  {
+    [HttpGet]
+    public IActionResult Get()
+    {
+      var result = new string[] { "value" };
+      return Ok(result);
+    }
+  }
+}

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/CustomControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/CustomControllerTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+using JsonApiDotNetCoreExample;
+
+namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
+{
+    [Collection("WebHostCollection")]
+    public class CustomControllerTests
+    {
+        [Fact]
+        public async Task NonJsonApiControllers_DoNotUse_Dasherized_Routes()
+        {
+            // arrange
+            var builder = new WebHostBuilder()
+                .UseStartup<Startup>();
+            var httpMethod = new HttpMethod("GET");
+            var route = $"testValues";
+
+            var server = new TestServer(builder);
+            var client = server.CreateClient();
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // act
+            var response = await client.SendAsync(request);
+            
+            // assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
Closes #86 
- ~Still needs tests~

Limitations:

- Limits the use of the dasherized route convention to JsonApiControllers
- All JsonApiController routes will be dasherized (to enable the opposite would require some extra work and breaking changes)