### PR TITLE
fix null ref on GetRelationshipsAsync

### DIFF
--- a/src/JsonApiDotNetCore/Internal/ContextGraph.cs
+++ b/src/JsonApiDotNetCore/Internal/ContextGraph.cs
@@ -46,7 +46,7 @@ namespace JsonApiDotNetCore.Internal
                     e.EntityType == entityType)
                 .Relationships
                 .FirstOrDefault(r => 
-                    r.InternalRelationshipName.ToLower() == relationshipName.ToLower())
+                    r.PublicRelationshipName.ToLower() == relationshipName.ToLower())
                 ?.InternalRelationshipName;
         }
     }

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>2.0.3</VersionPrefix>
     <TargetFrameworks>netstandard1.6</TargetFrameworks>
     <AssemblyName>JsonApiDotNetCore</AssemblyName>
     <PackageId>JsonApiDotNetCore</PackageId>

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -92,6 +92,8 @@ namespace JsonApiDotNetCore.Services
             if (relationshipName == null)
                 throw new JsonApiException("422", "Relationship name not specified.");
 
+            _logger.LogTrace($"Looking up '{relationshipName}'...");
+                                       
             var entity = await _entities.GetAndIncludeAsync(id, relationshipName);
             if (entity == null)
                 throw new JsonApiException("404", $"Relationship {relationshipName} not found.");
@@ -116,7 +118,7 @@ namespace JsonApiDotNetCore.Services
         public async Task UpdateRelationshipsAsync(TId id, string relationshipName, List<DocumentData> relationships)
         {
             relationshipName = _jsonApiContext.ContextGraph
-                      .GetRelationshipName<T>(relationshipName.ToProperCase());
+                      .GetRelationshipName<T>(relationshipName);
 
             if (relationshipName == null)
                 throw new JsonApiException("422", "Relationship name not specified.");


### PR DESCRIPTION
fix(context-graph): comparison should be against public relationship name
fix(resource-service): do not convert to proper case
causes null ref on GetRelationshipsAsync